### PR TITLE
Rakefile: LDFLAGS's -R flag is not supported on Linux, enable it only on OSX

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,9 @@ task :default do
 	end
 
 	prefix = Dir.pwd
-	ENV['LDFLAGS'] = "-R#{prefix}/lib"
+  if c['target_os'] =~ /darwin/i
+	  ENV['LDFLAGS'] = "-R#{prefix}/lib"
+  end
 
 	system! "mkdir -p lib"
 
@@ -26,8 +28,6 @@ task :default do
 		system! "make clean all"
 		system! "cp -r .libs/* ../lib/"
 	end
-
-	
 
 	Dir.chdir bindings do
 		ENV['RUBY'] ||= "#{c['bindir']}/#{c['RUBY_INSTALL_NAME']}"

--- a/Rakefile
+++ b/Rakefile
@@ -17,15 +17,14 @@ task :default do
 	end
 
 	prefix = Dir.pwd
-  if c['target_os'] =~ /darwin/i
-	  ENV['LDFLAGS'] = "-R#{prefix}/lib"
-  end
 
 	system! "mkdir -p lib"
 
 	Dir.chdir core do
 		system! "./configure --prefix=#{prefix} --exec-prefix=#{prefix}"
+		ENV['LDFLAGS'] = "-R#{prefix}/lib"
 		system! "make clean all"
+		ENV['LDFLAGS'] = ""
 		system! "cp -r .libs/* ../lib/"
 	end
 
@@ -33,7 +32,9 @@ task :default do
 		ENV['RUBY'] ||= "#{c['bindir']}/#{c['RUBY_INSTALL_NAME']}"
 		ENV['XAPIAN_CONFIG'] = xapian_config
 		system! "./configure --prefix=#{prefix} --exec-prefix=#{prefix} --with-ruby"
+		ENV['LDFLAGS'] = "-R#{prefix}/lib"
 		system! "make clean all"
+		ENV['LDFLAGS'] = ""
 	end
 
 	system! "cp -r #{bindings}/ruby/.libs/_xapian.* lib"


### PR DESCRIPTION
Rakefile: LDFLAGS's -R flag is not supported on Linux, enable it only on OSX

``` bash
$ rake
[snip]
./configure --prefix=/home/wael/.dotfiles/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/xapian-full-1.2.3 --exec-prefix=/home/wael/.dotfiles/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/xapian-full-1.2.3
checking for a BSD-compatible install... /bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking how to create a ustar tar archive... none
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking how to print strings... printf
checking for style of include used by make... GNU
checking for gcc... gcc
checking whether the C compiler works... no
configure: error: in `/home/wael/.dotfiles/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/xapian-full-1.2.3/xapian-core-1.2.3':
configure: error: C compiler cannot create executables
See `config.log' for more details.
rake aborted!
```

``` bash
$ cat xapian-core-*/config.log
[snip]
configure:3866: checking whether the C compiler works
configure:3888: gcc   -R/home/wael/.dotfiles/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/xapian-full-1.2.3/lib conftest.c  >&5
gcc: error: unrecognized option '-R'
configure:3892: $? = 1
configure:3930: result: no
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "xapian-core"
| #define PACKAGE_TARNAME "xapian-core"
| #define PACKAGE_VERSION "1.2.3"
| #define PACKAGE_STRING "xapian-core 1.2.3"
| #define PACKAGE_BUGREPORT "http://xapian.org/bugs"
| #define PACKAGE_URL ""
| #define PACKAGE "xapian-core"
| #define VERSION "1.2.3"
| /* end confdefs.h.  */
|
| int
| main ()
| {
|
|   ;
|   return 0;
| }
configure:3935: error: in `/home/wael/.dotfiles/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/xapian-full-1.2.3/xapian-core-1.2.3':
configure:3939: error: C compiler cannot create executables
[snip]
```
